### PR TITLE
fix: platform agnostic path

### DIFF
--- a/RogueliteSurvivor/RogueliteSurvivor/Game1.cs
+++ b/RogueliteSurvivor/RogueliteSurvivor/Game1.cs
@@ -5,6 +5,7 @@ using RogueliteSurvivor.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using TiledCS;
 
@@ -47,7 +48,7 @@ namespace RogueliteSurvivor
         {
             _spriteBatch = new SpriteBatch(GraphicsDevice);
 
-            map = new TiledMap(Content.RootDirectory + "\\Demo.tmx");
+            map = new TiledMap(Path.Combine(Content.RootDirectory, "Demo.tmx"));
             tilesets = map.GetTiledTilesets(Content.RootDirectory + "/");
             tilesetTexture = Content.Load<Texture2D>("Tiles");
 


### PR DESCRIPTION
Changes the path separator to work on Mac and Ubuntu through the `Path.Combine` method.